### PR TITLE
feat: New VRL functions for supporting AST representation

### DIFF
--- a/lib/stdlib/Cargo.toml
+++ b/lib/stdlib/Cargo.toml
@@ -8,6 +8,7 @@ license = "MPL-2.0"
 
 [dependencies]
 vrl = { path = "../.." }
+compiler = { package = "vrl-compiler", path = "../compiler", default-features = false }
 value = { path = "../value", default-features = false }
 
 datadog-filter = { path = "../datadog/filter", optional = true }
@@ -162,6 +163,12 @@ default = [
     "match_datadog_query",
     "md5",
     "merge",
+    "mezmo_arithmetic_operation",
+    "mezmo_is_truthy",
+    "mezmo_parse_float",
+    "mezmo_parse_int",
+    "mezmo_relational_comparison",
+    "mezmo_to_string",
     "mod",
     "now",
     "object",
@@ -323,6 +330,12 @@ match_array = ["dep:regex"]
 match_datadog_query = ["dep:datadog-search-syntax", "dep:datadog-filter", "dep:once_cell", "dep:regex", "dep:lookup_lib"]
 md5 = ["dep:md-5", "dep:hex"]
 merge = []
+mezmo_arithmetic_operation = ["mezmo_to_string"]
+mezmo_is_truthy = []
+mezmo_parse_int = ["parse_int"]
+mezmo_parse_float = ["to_float"]
+mezmo_relational_comparison = []
+mezmo_to_string = ["to_string"]
 mod = []
 now = ["dep:chrono"]
 object = []

--- a/lib/stdlib/src/is_mezmo_metric.rs
+++ b/lib/stdlib/src/is_mezmo_metric.rs
@@ -20,13 +20,11 @@ impl Function for IsMezmoMetric {
     }
 
     fn examples(&self) -> &'static [Example] {
-        &[
-            Example {
-                title: "counter",
-                source: r#"is_mezmo_metric({"kind":"incremental","name":"metric","value":{"type":"counter","value":1}})"#,
-                result: Ok("true"),
-            },
-        ]
+        &[Example {
+            title: "counter",
+            source: r#"is_mezmo_metric({"kind":"incremental","name":"metric","value":{"type":"counter","value":1}})"#,
+            result: Ok("true"),
+        }]
     }
 
     fn compile(
@@ -69,7 +67,7 @@ impl FunctionExpression for IsMezmoMetricFn {
 
 fn validate_metric(value: &Value) -> Result<Value> {
     if !value.is_object() {
-        return Err("expected an object".into())
+        return Err("expected an object".into());
     }
 
     if !value

--- a/lib/stdlib/src/lib.rs
+++ b/lib/stdlib/src/lib.rs
@@ -201,6 +201,20 @@ mod match_datadog_query;
 mod md5;
 #[cfg(feature = "merge")]
 mod merge;
+#[cfg(feature = "mezmo_arithmetic_operation")]
+mod mezmo_arithmetic_operation;
+#[cfg(feature = "mezmo_arithmetic_operation")]
+mod mezmo_concat_or_add;
+#[cfg(feature = "mezmo_is_truthy")]
+mod mezmo_is_truthy;
+#[cfg(feature = "mezmo_parse_float")]
+mod mezmo_parse_float;
+#[cfg(feature = "mezmo_parse_int")]
+mod mezmo_parse_int;
+#[cfg(feature = "mezmo_relational_comparison")]
+mod mezmo_relational_comparison;
+#[cfg(feature = "mezmo_to_string")]
+mod mezmo_to_string;
 #[cfg(feature = "mod")]
 mod mod_func;
 #[cfg(feature = "now")]
@@ -514,6 +528,20 @@ pub use match_array::MatchArray;
 pub use match_datadog_query::MatchDatadogQuery;
 #[cfg(feature = "merge")]
 pub use merge::Merge;
+#[cfg(feature = "mezmo_arithmetic_operation")]
+pub use mezmo_arithmetic_operation::{MezmoDivide, MezmoMultiply, MezmoSubtract};
+#[cfg(feature = "mezmo_arithmetic_operation")]
+pub use mezmo_concat_or_add::MezmoConcatOrAdd;
+#[cfg(feature = "mezmo_is_truthy")]
+pub use mezmo_is_truthy::MezmoIsTruthy;
+#[cfg(feature = "mezmo_parse_float")]
+pub use mezmo_parse_float::MezmoParseFloat;
+#[cfg(feature = "mezmo_parse_int")]
+pub use mezmo_parse_int::MezmoParseInt;
+#[cfg(feature = "mezmo_relational_comparison")]
+pub use mezmo_relational_comparison::{MezmoGt, MezmoGte, MezmoLt, MezmoLte};
+#[cfg(feature = "mezmo_to_string")]
+pub use mezmo_to_string::MezmoToString;
 #[cfg(feature = "mod")]
 pub use mod_func::Mod;
 #[cfg(feature = "now")]

--- a/lib/stdlib/src/mezmo_arithmetic_operation.rs
+++ b/lib/stdlib/src/mezmo_arithmetic_operation.rs
@@ -1,0 +1,225 @@
+use ::value::Value;
+use vrl::prelude::*;
+
+const ERROR_MESSAGE: &str = "Invalid arithmetic operation";
+
+type ArithmeticFn = fn(Value, Value) -> Resolved;
+
+fn subtract(left: Value, right: Value) -> Resolved {
+    left.try_sub(right).map_err(|_| ERROR_MESSAGE.into())
+}
+
+fn multiply(left: Value, right: Value) -> Resolved {
+    left.try_mul(right).map_err(|_| ERROR_MESSAGE.into())
+}
+
+fn divide(left: Value, right: Value) -> Resolved {
+    use Value::Integer;
+    match (&left, &right) {
+        // left.try_div() will always convert to f64 which is not correct for ints
+        (Integer(l), Integer(r)) => {
+            if *r == 0 {
+                return Err(ERROR_MESSAGE.into());
+            }
+            Ok(Value::from(l / r))
+        }
+        _ => left.try_div(right).map_err(|_| ERROR_MESSAGE.into()),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoSubtract;
+
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoMultiply;
+
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoDivide;
+
+macro_rules! implement_function {
+    ($type_name: ident, $identifier: expr, $fn_name: ident) => {
+        impl Function for $type_name {
+            fn identifier(&self) -> &'static str {
+                $identifier
+            }
+
+            fn examples(&self) -> &'static [Example] {
+                &[]
+            }
+
+            fn compile(
+                &self,
+                _state: &state::TypeState,
+                _ctx: &mut FunctionCompileContext,
+                arguments: ArgumentList,
+            ) -> Compiled {
+                let left = arguments.required("left");
+                let right = arguments.required("right");
+
+                Ok(ArithmeticOperatorFn {
+                    left,
+                    right,
+                    arithmetic_fn: $fn_name,
+                }
+                .as_expr())
+            }
+
+            fn parameters(&self) -> &'static [Parameter] {
+                &[
+                    Parameter {
+                        keyword: "left",
+                        kind: kind::ANY,
+                        required: true,
+                    },
+                    Parameter {
+                        keyword: "right",
+                        kind: kind::ANY,
+                        required: true,
+                    },
+                ]
+            }
+        }
+    };
+}
+
+implement_function!(MezmoSubtract, "mezmo_sub", subtract);
+implement_function!(MezmoMultiply, "mezmo_mul", multiply);
+implement_function!(MezmoDivide, "mezmo_div", divide);
+
+#[derive(Debug, Clone)]
+struct ArithmeticOperatorFn {
+    left: Box<dyn Expression>,
+    right: Box<dyn Expression>,
+    arithmetic_fn: ArithmeticFn,
+}
+
+impl FunctionExpression for ArithmeticOperatorFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let left = self.left.resolve(ctx)?;
+        let right = self.right.resolve(ctx)?;
+        (self.arithmetic_fn)(left, right)
+    }
+
+    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
+        TypeDef::integer().or_float().fallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        mezmo_sub => MezmoSubtract;
+
+        integer {
+            args: func_args![left: 20, right: 5],
+            want: Ok(15),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        float {
+            args: func_args![left: 20.5, right: 6.2],
+            want: Ok(14.3),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        integer_float {
+            args: func_args![left: 20, right: 5.5],
+            want: Ok(14.5),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        float_integer {
+            args: func_args![left: 20.5, right: 5],
+            want: Ok(15.5),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        float_object {
+            args: func_args![left: 20.5, right: value!({hello: 1})],
+            want: Err(ERROR_MESSAGE),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+    ];
+
+    test_function![
+        mezmo_mul => MezmoMultiply;
+
+        integer {
+            args: func_args![left: 20, right: 5],
+            want: Ok(100),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        float {
+            args: func_args![left: 0.5, right: 4.2],
+            want: Ok(2.1),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        integer_float {
+            args: func_args![left: 2, right: 5.5],
+            want: Ok(11.0),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        float_integer {
+            args: func_args![left: 20.1, right: 5],
+            want: Ok(100.5),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        integer_object {
+            args: func_args![left: 1, right: value!({hello: 1})],
+            want: Err(ERROR_MESSAGE),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+    ];
+
+    test_function![
+        mezmo_div => MezmoDivide;
+
+        integer {
+            args: func_args![left: 20, right: 5],
+            want: Ok(4),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        float {
+            args: func_args![left: 100, right: 4.8],
+            want: Ok(20.833333333333336),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        integer_float {
+            args: func_args![left: 10.1, right: 0.5],
+            want: Ok(20.2),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        float_integer {
+            args: func_args![left: 20.5, right: 5],
+            want: Ok(4.1),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        integer_null {
+            args: func_args![left: 1, right: value!(null)],
+            want: Err(ERROR_MESSAGE),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        integer_zero {
+            args: func_args![left: 1, right: 0],
+            want: Err(ERROR_MESSAGE),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+
+        float_zero {
+            args: func_args![left: 1.1, right: 0.0],
+            want: Err(ERROR_MESSAGE),
+            tdef: TypeDef::integer().or_float().fallible(),
+        }
+    ];
+}

--- a/lib/stdlib/src/mezmo_concat_or_add.rs
+++ b/lib/stdlib/src/mezmo_concat_or_add.rs
@@ -1,0 +1,150 @@
+use crate::mezmo_to_string;
+use ::value::Value;
+use vrl::prelude::*;
+
+const ERROR_MESSAGE: &str = "Cannot add or concat other values that are not strings or numbers";
+
+/// Concatenates if any of the parameters is a string.
+/// Adds if both are numbers.
+fn concat_or_add(left: Value, right: Value) -> Resolved {
+    use Value::{Bytes, Float, Integer};
+    match (&left, &right) {
+        (Bytes(_), _) | (_, Bytes(_)) => {
+            let left = mezmo_to_string::to_string(left);
+            let right = mezmo_to_string::to_string(right);
+            Ok(Value::from(left + &right))
+        }
+        (Float(l), Float(r)) => Ok(Value::from(l.into_inner() + r.into_inner())),
+        (Float(l), Integer(r)) => Ok(Value::from(l.into_inner() + *r as f64)),
+        (Integer(l), Float(r)) => Ok(Value::from(*l as f64 + r.into_inner())),
+        (Integer(l), Integer(r)) => Ok(Value::from(l + r)),
+        _ => Err(ERROR_MESSAGE.into()),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoConcatOrAdd;
+
+impl Function for MezmoConcatOrAdd {
+    fn identifier(&self) -> &'static str {
+        "mezmo_concat_or_add"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "left",
+                kind: kind::ANY,
+                required: true,
+            },
+            Parameter {
+                keyword: "right",
+                kind: kind::ANY,
+                required: true,
+            },
+        ]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[]
+    }
+
+    fn compile(
+        &self,
+        _state: &state::TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let left = arguments.required("left");
+        let right = arguments.required("right");
+
+        Ok(MezmoConcatOrAddFn { left, right }.as_expr())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MezmoConcatOrAddFn {
+    left: Box<dyn Expression>,
+    right: Box<dyn Expression>,
+}
+
+impl FunctionExpression for MezmoConcatOrAddFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let left = self.left.resolve(ctx)?;
+        let right = self.right.resolve(ctx)?;
+        concat_or_add(left, right)
+    }
+
+    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
+        TypeDef::bytes().or_integer().or_float().fallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        mezmo_concat_or_add => MezmoConcatOrAdd;
+
+        integer {
+            args: func_args![left: 1, right: 2],
+            want: Ok(3),
+            tdef: TypeDef::bytes().or_integer().or_float().fallible(),
+        }
+
+        float {
+            args: func_args![left: 1.3, right: 8.6],
+            want: Ok(9.9),
+            tdef: TypeDef::bytes().or_integer().or_float().fallible(),
+        }
+
+        float_integer {
+            args: func_args![left: 1.2, right: 2],
+            want: Ok(3.2),
+            tdef: TypeDef::bytes().or_integer().or_float().fallible(),
+        }
+
+        integer_float {
+            args: func_args![left: 1, right: 2.9],
+            want: Ok(3.9),
+            tdef: TypeDef::bytes().or_integer().or_float().fallible(),
+        }
+
+        string {
+            args: func_args![left: "abc", right: "d"],
+            want: Ok("abcd"),
+            tdef: TypeDef::bytes().or_integer().or_float().fallible(),
+        }
+
+        string_and_integer {
+            args: func_args![left: "$ ", right: 1],
+            want: Ok("$ 1"),
+            tdef: TypeDef::bytes().or_integer().or_float().fallible(),
+        }
+
+        float_string {
+            args: func_args![left: 123.45, right: " €"],
+            want: Ok("123.45 €"),
+            tdef: TypeDef::bytes().or_integer().or_float().fallible(),
+        }
+
+        string_null {
+            args: func_args![left: "abc", right: value!(null)],
+            want: Ok("abc"),
+            tdef: TypeDef::bytes().or_integer().or_float().fallible(),
+        }
+
+        integer_null {
+            args: func_args![left: 1, right: value!(null)],
+            want: Err(ERROR_MESSAGE),
+            tdef: TypeDef::bytes().or_integer().or_float().fallible(),
+        }
+
+        float_boolean {
+            args: func_args![left: 1.1, right: true],
+            want: Err(ERROR_MESSAGE),
+            tdef: TypeDef::bytes().or_integer().or_float().fallible(),
+        }
+    ];
+}

--- a/lib/stdlib/src/mezmo_is_truthy.rs
+++ b/lib/stdlib/src/mezmo_is_truthy.rs
@@ -1,0 +1,142 @@
+use ::value::Value;
+use vrl::prelude::*;
+
+fn is_truthy(value: Value) -> bool {
+    use Value::{Boolean, Bytes, Float, Integer, Null};
+    match value {
+        Float(v) => v != 0.0,
+        Integer(v) => v != 0,
+        Boolean(v) => v,
+        Null => false,
+        Bytes(v) => v.len() > 0,
+        _ => true,
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoIsTruthy;
+
+impl Function for MezmoIsTruthy {
+    fn identifier(&self) -> &'static str {
+        "mezmo_is_truthy"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::ANY,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "integer",
+                source: "mezmo_is_truthy(5)",
+                result: Ok("true"),
+            },
+            Example {
+                title: "float",
+                source: "mezmo_is_truthy(5.6)",
+                result: Ok("true"),
+            },
+            Example {
+                title: "integer",
+                source: "mezmo_is_truthy(0)",
+                result: Ok("false"),
+            },
+            Example {
+                title: "true",
+                source: "mezmo_is_truthy(true)",
+                result: Ok("true"),
+            },
+        ]
+    }
+
+    fn compile(
+        &self,
+        _state: &state::TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(MezmoIsTruthyFn { value }.as_expr())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MezmoIsTruthyFn {
+    value: Box<dyn Expression>,
+}
+
+impl FunctionExpression for MezmoIsTruthyFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        Ok(is_truthy(value).into())
+    }
+
+    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
+        TypeDef::boolean().infallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::prelude::*;
+
+    use super::*;
+
+    test_function![
+        is_truthy => MezmoIsTruthy;
+
+        float {
+            args: func_args![value: 20.5],
+            want: Ok(true),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        float_zero {
+            args: func_args![value: 0.0],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        integer_zero {
+            args: func_args![value: 0],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        integer_negative {
+            args: func_args![value: -1],
+            want: Ok(true),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        string {
+            args: func_args![value: "abc"],
+            want: Ok(true),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        string_empty {
+            args: func_args![value: ""],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        null {
+            args: func_args![value: value!(null)],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        timestamp {
+             args: func_args![value: Utc.ymd(2014, 7, 8).and_hms_milli(9, 10, 11, 12)],
+             want: Ok(true),
+             tdef: TypeDef::boolean().infallible(),
+        }
+    ];
+}

--- a/lib/stdlib/src/mezmo_parse_float.rs
+++ b/lib/stdlib/src/mezmo_parse_float.rs
@@ -1,0 +1,95 @@
+use crate::to_float;
+use ::value::Value;
+use vrl::prelude::*;
+
+/// Converts any value to float, defaulting to f64(0).
+fn mezmo_parse_float(value: Value) -> f64 {
+    use Value::Float;
+    let v = to_float::to_float(value).unwrap_or_else(|_| Value::from(0.0));
+    match v {
+        Float(v) => v.into_inner(),
+        _ => 0.0,
+    }
+}
+
+/// Infallible counterpart of ToFloat
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoParseFloat;
+
+impl Function for MezmoParseFloat {
+    fn identifier(&self) -> &'static str {
+        "mezmo_parse_float"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::ANY,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[]
+    }
+
+    fn compile(
+        &self,
+        _state: &state::TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(ParseFloatFn { value }.as_expr())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ParseFloatFn {
+    value: Box<dyn Expression>,
+}
+
+impl FunctionExpression for ParseFloatFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        Ok(mezmo_parse_float(value).into())
+    }
+
+    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
+        TypeDef::float().infallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        mezmo_parse_float => MezmoParseFloat;
+
+        float {
+            args: func_args![value: 20.5],
+            want: Ok(20.5),
+            tdef: TypeDef::float().infallible(),
+        }
+
+        integer {
+            args: func_args![value: 100],
+            want: Ok(100.0),
+            tdef: TypeDef::float().infallible(),
+        }
+
+        string {
+            args: func_args![value: "100.1"],
+            want: Ok(100.1),
+            tdef: TypeDef::float().infallible(),
+        }
+
+        null {
+            args: func_args![value: value!(null)],
+            want: Ok(0.0),
+            tdef: TypeDef::float().infallible(),
+        }
+    ];
+}

--- a/lib/stdlib/src/mezmo_parse_int.rs
+++ b/lib/stdlib/src/mezmo_parse_int.rs
@@ -1,0 +1,158 @@
+use crate::parse_int;
+use ::value::Value;
+use vrl::prelude::*;
+
+/// Converts any value into an int, defaulting to 0.
+fn mezmo_parse_int(value: Value, base: Option<Value>) -> i64 {
+    use Value::{Bytes, Float, Integer};
+    match value {
+        Integer(v) => v,
+        Float(v) => v.into_inner() as i64,
+        Bytes(_) => {
+            let v = parse_int::parse_int(value, base).unwrap_or_else(|_| Value::from(0));
+            match v {
+                Integer(v) => v,
+                _ => 0,
+            }
+        }
+        _ => 0,
+    }
+}
+
+/// Infallible counterpart of ParseInt
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoParseInt;
+
+impl Function for MezmoParseInt {
+    fn identifier(&self) -> &'static str {
+        "mezmo_parse_int"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::ANY,
+                required: true,
+            },
+            Parameter {
+                keyword: "base",
+                kind: kind::INTEGER,
+                required: false,
+            },
+        ]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[]
+    }
+
+    fn compile(
+        &self,
+        _state: &state::TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+        let base = arguments.optional("base");
+
+        Ok(ParseIntFn { value, base }.as_expr())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ParseIntFn {
+    value: Box<dyn Expression>,
+    base: Option<Box<dyn Expression>>,
+}
+
+impl FunctionExpression for ParseIntFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        let base = self
+            .base
+            .as_ref()
+            .map(|expr| expr.resolve(ctx))
+            .transpose()?;
+        Ok(mezmo_parse_int(value, base).into())
+    }
+
+    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
+        TypeDef::integer().infallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        mezmo_parse_int => MezmoParseInt;
+
+        float {
+            args: func_args![value: 20.5],
+            want: Ok(20),
+            tdef: TypeDef::integer().infallible(),
+        }
+
+        integer {
+            args: func_args![value: 100],
+            want: Ok(100),
+            tdef: TypeDef::integer().infallible(),
+        }
+
+        null {
+            args: func_args![value: value!(null)],
+            want: Ok(0),
+            tdef: TypeDef::integer().infallible(),
+        }
+
+        text {
+            args: func_args![value: "hello"],
+            want: Ok(0),
+            tdef: TypeDef::integer().infallible(),
+        }
+
+        boolean {
+            args: func_args![value: true],
+            want: Ok(0),
+            tdef: TypeDef::integer().infallible(),
+        }
+
+        decimal {
+            args: func_args![value: "-42"],
+            want: Ok(-42),
+            tdef: TypeDef::integer().infallible(),
+        }
+
+        binary {
+            args: func_args![value: "0b1001"],
+            want: Ok(9),
+            tdef: TypeDef::integer().infallible(),
+        }
+
+        octal {
+            args: func_args![value: "042"],
+            want: Ok(34),
+            tdef: TypeDef::integer().infallible(),
+        }
+
+        hexadecimal {
+            args: func_args![value: "0x2a"],
+            want: Ok(42),
+            tdef: TypeDef::integer().infallible(),
+        }
+
+        zero {
+            args: func_args![value: "0"],
+            want: Ok(0),
+            tdef: TypeDef::integer().infallible(),
+        }
+
+        explicit_hexadecimal {
+            args: func_args![value: "2a", base: 16],
+            want: Ok(42),
+            tdef: TypeDef::integer().infallible(),
+        }
+    ];
+}

--- a/lib/stdlib/src/mezmo_relational_comparison.rs
+++ b/lib/stdlib/src/mezmo_relational_comparison.rs
@@ -1,0 +1,271 @@
+use ::value::Value;
+use vrl::prelude::*;
+use vrl::value::Error;
+
+type ComparisonFn = fn(Value, Value) -> bool;
+
+fn gt(left: Value, right: Value) -> bool {
+    value_to_boolean(left.try_gt(right))
+}
+
+fn gte(left: Value, right: Value) -> bool {
+    value_to_boolean(left.try_ge(right))
+}
+
+fn lt(left: Value, right: Value) -> bool {
+    value_to_boolean(left.try_lt(right))
+}
+
+fn lte(left: Value, right: Value) -> bool {
+    value_to_boolean(left.try_le(right))
+}
+
+fn value_to_boolean(value: std::result::Result<Value, Error>) -> bool {
+    use Value::Boolean;
+
+    match value.unwrap_or_else(|_| Boolean(false)) {
+        Boolean(v) => v,
+        _ => false,
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoGt;
+
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoGte;
+
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoLt;
+
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoLte;
+
+macro_rules! implement_function {
+    ($type_name: ident, $identifier: expr, $fn_name: ident) => {
+        impl Function for $type_name {
+            fn identifier(&self) -> &'static str {
+                $identifier
+            }
+
+            fn examples(&self) -> &'static [Example] {
+                &[]
+            }
+
+            fn compile(
+                &self,
+                _state: &state::TypeState,
+                _ctx: &mut FunctionCompileContext,
+                arguments: ArgumentList,
+            ) -> Compiled {
+                let left = arguments.required("left");
+                let right = arguments.required("right");
+
+                Ok(RelationalOperatorFn {
+                    left,
+                    right,
+                    comparison_fn: $fn_name,
+                }
+                .as_expr())
+            }
+
+            fn parameters(&self) -> &'static [Parameter] {
+                &[
+                    Parameter {
+                        keyword: "left",
+                        kind: kind::ANY,
+                        required: true,
+                    },
+                    Parameter {
+                        keyword: "right",
+                        kind: kind::ANY,
+                        required: true,
+                    },
+                ]
+            }
+        }
+    };
+}
+
+implement_function!(MezmoGt, "mezmo_gt", gt);
+implement_function!(MezmoGte, "mezmo_gte", gte);
+implement_function!(MezmoLt, "mezmo_lt", lt);
+implement_function!(MezmoLte, "mezmo_lte", lte);
+
+#[derive(Debug, Clone)]
+struct RelationalOperatorFn {
+    left: Box<dyn Expression>,
+    right: Box<dyn Expression>,
+    comparison_fn: ComparisonFn,
+}
+
+impl FunctionExpression for RelationalOperatorFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let left = self.left.resolve(ctx)?;
+        let right = self.right.resolve(ctx)?;
+        Ok((self.comparison_fn)(left, right).into())
+    }
+
+    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
+        TypeDef::boolean().infallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        mezmo_gt => MezmoGt;
+
+        integer {
+            args: func_args![left: 20, right: 5],
+            want: Ok(true),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        integer_float {
+            args: func_args![left: 20, right: 100.23],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        float {
+            args: func_args![left: 20.5, right: 0.0],
+            want: Ok(true),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        float_equal {
+            args: func_args![left: 1.1, right: 1.1],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        float_less_than {
+            args: func_args![left: 1.1, right: 100.1],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        float_null {
+            args: func_args![left: 1.1, right: value!(null)],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+    ];
+
+    test_function![
+        mezmo_gte => MezmoGte;
+
+        integer {
+            args: func_args![left: 20, right: 5],
+            want: Ok(true),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        integer_float {
+            args: func_args![left: 20.1, right: 100],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        float {
+            args: func_args![left: 20.5, right: 0.0],
+            want: Ok(true),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        float_less_than {
+            args: func_args![left: 1.1, right: 100.1],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        float_equal {
+            args: func_args![left: 1.1, right: 1.1],
+            want: Ok(true),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        integer_null {
+            args: func_args![left: value!(null), right: 2],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        integer_array {
+            args: func_args![left: value!([1, 2]), right: 2],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+    ];
+
+    test_function![
+        mezmo_lt => MezmoLt;
+
+        integer_float {
+            args: func_args![left: 20, right: 100.23],
+            want: Ok(true),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        integer_greater_than {
+            args: func_args![left: 20, right: 5],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        integer_less_than {
+            args: func_args![left: 0, right: 5],
+            want: Ok(true),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        float_equal {
+            args: func_args![left: 1.1, right: 1.1],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        object_left {
+            args: func_args![left: value!({foo: "bar"}), right: 1],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        object_right {
+            args: func_args![left: 1.1, right: value!({foo: "bar"})],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+    ];
+
+    test_function![
+        mezmo_lte => MezmoLte;
+
+        integer_float {
+            args: func_args![left: 20, right: 100.23],
+            want: Ok(true),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        integer_float_greater_than {
+            args: func_args![left: 20.1, right: 5],
+            want: Ok(false),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        integer_less_than {
+            args: func_args![left: 0, right: 5],
+            want: Ok(true),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        float_equal {
+            args: func_args![left: 1.1, right: 1.1],
+            want: Ok(true),
+            tdef: TypeDef::boolean().infallible(),
+        }
+    ];
+}

--- a/lib/stdlib/src/mezmo_to_string.rs
+++ b/lib/stdlib/src/mezmo_to_string.rs
@@ -1,0 +1,137 @@
+use crate::to_string;
+use ::value::Value;
+use vrl::prelude::*;
+
+/// Converts any value into a string.
+/// Returns "[Array]" for arrays, "[Object]" for objects and "" for nulls.
+pub(crate) fn to_string(value: Value) -> String {
+    use Value::{Array, Bytes, Object};
+    match value {
+        Array(_) => "[Array]".into(),
+        Object(_) => "[Object]".into(),
+        _ => {
+            let bytes = to_string::to_string(value).unwrap_or_else(|_| Value::from(""));
+            match bytes {
+                Bytes(v) => std::str::from_utf8(&v).unwrap_or("").into(),
+                _ => "".into(),
+            }
+        }
+    }
+}
+
+/// Infallible counterpart of ToString
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoToString;
+
+impl Function for MezmoToString {
+    fn identifier(&self) -> &'static str {
+        "mezmo_to_string"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::ANY,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[Example {
+            title: "float",
+            source: "mezmo_to_string(5.6)",
+            result: Ok("5.6"),
+        }]
+    }
+
+    fn compile(
+        &self,
+        _state: &state::TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(MezmoToStringFn { value }.as_expr())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MezmoToStringFn {
+    value: Box<dyn Expression>,
+}
+
+impl FunctionExpression for MezmoToStringFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        Ok(to_string(value).into())
+    }
+
+    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
+        TypeDef::bytes().infallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    test_function![
+        mezmo_to_string => MezmoToString;
+
+        float {
+            args: func_args![value: 20.5],
+            want: Ok("20.5"),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+        integer {
+            args: func_args![value: 0],
+            want: Ok("0"),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+        integer_negative {
+            args: func_args![value: -111],
+            want: Ok("-111"),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+        integer_string {
+            args: func_args![value: "my string"],
+            want: Ok("my string"),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+        null {
+            args: func_args![value: value!(null)],
+            want: Ok(""),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+        array {
+            args: func_args![value: value!([1, 2])],
+            want: Ok("[Array]"),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+        object {
+            args: func_args![value: value!({hello: 1})],
+            want: Ok("[Object]"),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+        timestamp {
+            args: func_args![value: Utc.ymd(2021, 1, 1).and_hms_milli(5, 12, 0, 0)],
+            want: Ok("2021-01-01T05:12:00Z"),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+        boolean {
+            args: func_args![value: false],
+            want: Ok("false"),
+            tdef: TypeDef::bytes().infallible(),
+        }
+    ];
+}

--- a/lib/stdlib/src/parse_int.rs
+++ b/lib/stdlib/src/parse_int.rs
@@ -1,7 +1,7 @@
 use ::value::Value;
 use vrl::prelude::*;
 
-fn parse_int(value: Value, base: Option<Value>) -> Resolved {
+pub(crate) fn parse_int(value: Value, base: Option<Value>) -> Resolved {
     let string = value.try_bytes_utf8_lossy()?;
     let (base, index) = match base {
         Some(base) => {

--- a/lib/stdlib/src/to_float.rs
+++ b/lib/stdlib/src/to_float.rs
@@ -2,7 +2,7 @@ use ::value::Value;
 use vrl::prelude::*;
 use vrl_core::conversion::Conversion;
 
-fn to_float(value: Value) -> Resolved {
+pub(crate) fn to_float(value: Value) -> Resolved {
     use Value::{Boolean, Bytes, Float, Integer, Null, Timestamp};
     match value {
         Float(_) => Ok(value),

--- a/lib/stdlib/src/to_string.rs
+++ b/lib/stdlib/src/to_string.rs
@@ -1,7 +1,7 @@
 use ::value::Value;
 use vrl::prelude::*;
 
-fn to_string(value: Value) -> Resolved {
+pub(crate) fn to_string(value: Value) -> Resolved {
     use chrono::SecondsFormat;
     use Value::{Boolean, Bytes, Float, Integer, Null, Timestamp};
     let value = match value {


### PR DESCRIPTION
In VRL some expressions can be conditionally fallible like binary expressions with relational operators, e.g., "a > b" or arithmetic operations. This patch adds functions to support infallible equivalents when possible, along with clear fallibility conditions for other functions.

Ref: LOG-16833