### PR TITLE
fix: Wrong signature types for slice and substring

### DIFF
--- a/lib/stdlib/src/mezmo_string_slice.rs
+++ b/lib/stdlib/src/mezmo_string_slice.rs
@@ -58,13 +58,13 @@ impl Function for MezmoStringSlice {
                 required: true,
             },
             Parameter {
-                keyword: "index",
+                keyword: "index_start",
                 kind: kind::INTEGER,
                 required: true,
             },
             Parameter {
-                keyword: "allow_negative",
-                kind: kind::BOOLEAN,
+                keyword: "index_end",
+                kind: kind::INTEGER,
                 required: false,
             },
         ]

--- a/lib/stdlib/src/mezmo_substring.rs
+++ b/lib/stdlib/src/mezmo_substring.rs
@@ -52,13 +52,13 @@ impl Function for MezmoSubstring {
                 required: true,
             },
             Parameter {
-                keyword: "index",
+                keyword: "index_start",
                 kind: kind::INTEGER,
                 required: true,
             },
             Parameter {
-                keyword: "allow_negative",
-                kind: kind::BOOLEAN,
+                keyword: "index_end",
+                kind: kind::INTEGER,
                 required: false,
             },
         ]


### PR DESCRIPTION
Fixes incorrect signature types for `mezmo_string_slice()` and `mezmo_substring()`.

Ref: LOG-17381