### PR TITLE
ci: Setup repo in Jenkins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @answerbook/pipeline

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,25 @@
+{
+  "ci": false,
+  "branches": [
+    "main"
+  ],
+  "extends": [
+    "@answerbook/release-config-logdna"
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    ["@semantic-release/exec", {
+      "prepareCmd": "semantic-release-cargo prepare ${nextRelease.version}; cargo update --workspace; sleep 2"
+    }],
+    "@semantic-release/github",
+    ["@semantic-release/git", {
+      "assets": [
+        "CHANGELOG.md",
+        "**/Cargo.toml",
+        "Cargo.lock"
+      ]
+    }]
+  ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrl"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 publish = false
@@ -52,11 +52,11 @@ bytes = "1.4.0"
 compiler = { package = "vrl-compiler", path = "lib/compiler", default-features = false }
 diagnostic = { package = "vrl-diagnostic", path = "lib/diagnostic" }
 indoc = "2"
-lookup = { path = "lib/lookup" }
+lookup = { path = "lib/lookup" , version = "0.3.0" }
 ordered-float = "3"
 parser = { package = "vrl-parser", path = "lib/parser" }
-value = { path = "lib/value", default-features = false }
-vrl-core = { path = "lib/core" }
+value = { path = "lib/value", default-features = false , version = "0.3.0" }
+vrl-core = { path = "lib/core" , version = "0.3.0" }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:1.68.2 AS base
+
+WORKDIR /opt/app
+
+COPY Cargo.toml /opt/app/
+COPY benches /opt/app/benches
+COPY lib /opt/app/lib
+COPY src /opt/app/src
+
+RUN cargo check
+RUN cargo test
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,164 @@
+library "magic-butler-catalogue"
+def PROJECT_NAME = "vrl"
+def DEFAULT_BRANCH = "main"
+def CURRENT_BRANCH = [env.CHANGE_BRANCH, env.BRANCH_NAME]?.find{branch -> branch != null}
+def DRY_RUN = CURRENT_BRANCH != DEFAULT_BRANCH
+
+pipeline {
+    agent {
+        node {
+            label "ec2-fleet"
+            customWorkspace("/tmp/workspace/${env.BUILD_TAG}")
+        }
+    }
+
+    parameters {
+        string(name: "SANITY_BUILD", defaultValue: "", description: "Is this a scheduled sanity build that skips releasing?")
+    }
+
+    triggers {
+        parameterizedCron(
+            // Cron hours are in GMT, so this is roughly 12-3am EST, depending on DST
+            env.BRANCH_NAME == DEFAULT_BRANCH ? "H H(5-6) * * * % SANITY_BUILD=true" : ""
+        )
+    }
+
+    options {
+        timeout time: 1, unit: "HOURS"
+        timestamps()
+        ansiColor "xterm"
+    }
+
+    environment {
+        GITHUB_TOKEN = credentials("github-api-token")
+        NPM_CONFIG_CACHE = ".npm"
+        NPM_CONFIG_USERCONFIG = ".npm/rc"
+        SPAWN_WRAP_SHIM_ROOT = ".npm"
+        RUSTUP_HOME = "/opt/rust/cargo"
+        CARGO_HOME = "/opt/rust/cargo"
+        PATH = """${sh(
+           returnStdout: true,
+           script: 'echo /opt/rust/cargo/bin:\$PATH'
+        )}
+        """
+        // for the semantic-release-rust executable, we must have this set even when not publishing the crate directly
+        CARGO_REGISTRY_TOKEN = "not-in-use"
+    }
+
+    post {
+        always {
+            script {
+                jiraSendBuildInfo site: "logdna.atlassian.net"
+
+                if (env.SANITY_BUILD == "true") {
+                    notifySlack(
+                        currentBuild.currentResult,
+                        [
+                            channel: "#pipeline-bots",
+                            tokenCredentialId: "qa-slack-token"
+                        ],
+                        "`${PROJECT_NAME}` sanity build took ${currentBuild.durationString.replaceFirst(' and counting', '')}."
+                    )
+                }
+            }
+        }
+    }
+
+    stages {
+        stage("Validate") {
+            tools {
+                nodejs "NodeJS 18"
+            }
+
+            steps {
+                script {
+                    sh "mkdir -p ${NPM_CONFIG_CACHE}"
+                    npm.auth token: GITHUB_TOKEN
+                    sh "npx @answerbook/commitlint-config-logdna"
+                }
+            }
+        }
+
+        stage("Test") {
+            when {
+                beforeAgent true
+                not {
+                    changelog "\\[skip ci\\]"
+                }
+            }
+
+            parallel {
+                stage("Rust Unit Tests") {
+                    steps {
+                        script {
+                            sh "docker build --progress=plain --target base ."
+                        }
+                    }
+                }
+
+                stage("Release Test") {
+                    when {
+                        beforeAgent true
+                        not {
+                            branch DEFAULT_BRANCH
+                        }
+                    }
+
+                    environment {
+                        GIT_BRANCH = "${CURRENT_BRANCH}"
+                        BRANCH_NAME = "${CURRENT_BRANCH}"
+                        CHANGE_ID = ""
+                    }
+
+                    tools {
+                        nodejs 'NodeJS 18'
+                    }
+
+                    steps {
+                        script {
+                            sh "mkdir -p ${NPM_CONFIG_CACHE}"
+                            npm.auth token: GITHUB_TOKEN
+                            sh "cargo install semantic-release-cargo --version 2.1.92"
+                            sh "npm install -G semantic-release@^19.0.0 @semantic-release/git@10.0.1 @semantic-release/changelog@6.0.3 @semantic-release/exec@6.0.3 @answerbook/release-config-logdna@2.0.0"
+                            sh 'npx semantic-release --dry-run --no-ci --branches=${BRANCH_NAME:-main}'
+                        }
+                    }
+                }
+            }
+        }
+
+        stage("Release") {
+            when {
+                beforeAgent true
+                branch DEFAULT_BRANCH
+                not {
+                    allOf {
+                        changelog "\\[skip ci\\]"
+                        environment name: "SANITY_BUILD", value: "true"
+                    }
+                }
+            }
+
+            tools {
+                nodejs "NodeJS 18"
+            }
+
+            steps {
+                script {
+                    sh "mkdir -p ${NPM_CONFIG_CACHE}"
+                    npm.auth token: GITHUB_TOKEN
+                    sh "cargo install semantic-release-cargo --version 2.1.92"
+                    sh "npm install -G semantic-release@^19.0.0 @semantic-release/git@10.0.1 @semantic-release/changelog@6.0.3 @semantic-release/exec@6.0.3 @answerbook/release-config-logdna@2.0.0"
+                    sh "npx semantic-release"
+
+                    def RELEASE_VERSION = sh(
+                        returnStdout: true,
+                        script: "cargo metadata -q --no-deps --format-version 1 | jq -r \'.packages[0].version\'"
+                    ).trim()
+
+                    sh "docker build --progress=plain --target base ."
+                }
+            }
+        }
+    }
+}

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrl-cli"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 publish = false
@@ -20,11 +20,11 @@ regex = { version = "1", default-features = false, optional = true, features = [
 rustyline = { version = "11", default-features = false, optional = true }
 serde_json = "1"
 thiserror = "1"
-vrl = { path = "../..", default-features = false }
+vrl = { path = "../..", default-features = false , version = "0.3.0" }
 core = { package = "vrl-core", path = "../core", default-features = false }
-value = { path = "../value", default-features = false, features = [] }
+value = { path = "../value", default-features = false, features = [] , version = "0.3.0" }
 webbrowser = { version = "0.8", default-features = false, optional = true }
-lookup = { package = "lookup", path = "../lookup" }
+lookup = { package = "lookup", path = "../lookup" , version = "0.3.0" }
 
 [dependencies.stdlib]
 package = "vrl-stdlib"

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrl-compiler"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 publish = false
@@ -31,8 +31,8 @@ test = []
 core = { package = "vrl-core", path = "../core", default-features = false }
 diagnostic = { package = "vrl-diagnostic", path = "../diagnostic" }
 parser = { package = "vrl-parser", path = "../parser" }
-lookup = { path = "../lookup" }
-value = { path = "../value" }
+lookup = { path = "../lookup" , version = "0.3.0" }
+value = { path = "../value" , version = "0.3.0" }
 getrandom = { version = "0.2", features = ["js"] }
 
 bytes = { version = "1.4.0", default-features = false }

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "vrl-core"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-lookup = { path = "../lookup" }
-value = { path = "../value", features = ["json"] }
+lookup = { path = "../lookup" , version = "0.3.0" }
+value = { path = "../value", features = ["json"] , version = "0.3.0" }
 derivative = "2.1.3"
 diagnostic = { package = "vrl-diagnostic", path = "../diagnostic" }
 chrono-tz = { version = "0.8.1", default-features = false }

--- a/lib/datadog/filter/Cargo.toml
+++ b/lib/datadog/filter/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "datadog-filter"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 publish = false
 license = "MPL-2.0"
 
 [dependencies]
-datadog-search-syntax = { path = "../search-syntax" }
+datadog-search-syntax = { path = "../search-syntax" , version = "0.3.0" }
 
 regex = "1"
 dyn-clone = { version = "1.0.11", default-features = false }

--- a/lib/datadog/grok/Cargo.toml
+++ b/lib/datadog/grok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-grok"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 build = "build.rs" # LALRPOP preprocessing
@@ -22,9 +22,9 @@ thiserror = { version = "1", default-features = false }
 tracing = { version = "0.1.34", default-features = false }
 
 # Internal
-lookup = { path = "../../lookup" }
-value = {path = "../../value", features = ["json", "test"]}
-vrl-compiler = { path = "../../compiler" }
+lookup = { path = "../../lookup" , version = "0.3.0" }
+value = {path = "../../value", features = ["json", "test"], version = "0.3.0" }
+vrl-compiler = { path = "../../compiler" , version = "0.3.0" }
 
 [dev-dependencies]
 vrl-compiler = { path = "../../compiler" }

--- a/lib/datadog/search-syntax/Cargo.toml
+++ b/lib/datadog/search-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-search-syntax"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 publish = false

--- a/lib/diagnostic/Cargo.toml
+++ b/lib/diagnostic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrl-diagnostic"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 publish = false

--- a/lib/lookup/Cargo.toml
+++ b/lib/lookup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lookup"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 publish = false

--- a/lib/parser/Cargo.toml
+++ b/lib/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrl-parser"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 publish = false
@@ -8,7 +8,7 @@ build = "build.rs" # LALRPOP preprocessing
 
 [dependencies]
 diagnostic = { package = "vrl-diagnostic", path = "../diagnostic" }
-lookup = { path = "../lookup" }
+lookup = { path = "../lookup" , version = "0.3.0" }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 
 lalrpop-util = "0.19"

--- a/lib/proptests/Cargo.toml
+++ b/lib/proptests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proptests"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Stephen Wakely <fungus.humungus@gmail.com>"]
 edition = "2021"
 
@@ -12,4 +12,4 @@ proptest = "1.1"
 ordered-float = "3"
 parser = { package = "vrl-parser", path = "../parser/" }
 diagnostic = { package = "vrl-diagnostic", path = "../diagnostic/" }
-lookup = { path = "../lookup/" }
+lookup = { path = "../lookup/" , version = "0.3.0" }

--- a/lib/stdlib/Cargo.toml
+++ b/lib/stdlib/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "vrl-stdlib"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 publish = false
 license = "MPL-2.0"
 
 [dependencies]
-vrl = { path = "../.." }
+vrl = { path = "../.." , version = "0.3.0" }
 compiler = { package = "vrl-compiler", path = "../compiler", default-features = false }
-value = { path = "../value", default-features = false }
+value = { path = "../value", default-features = false , version = "0.3.0" }
 
-datadog-filter = { path = "../datadog/filter", optional = true }
-datadog-search-syntax = { path = "../datadog/search-syntax", optional = true }
+datadog-filter = { path = "../datadog/filter", optional = true , version = "0.3.0" }
+datadog-search-syntax = { path = "../datadog/search-syntax", optional = true , version = "0.3.0" }
 lookup_lib = {package = "lookup", path = "../lookup", optional = true }
-vrl-core = { path = "../core" }
-vrl-diagnostic = { path = "../diagnostic" }
+vrl-core = { path = "../core" , version = "0.3.0" }
+vrl-diagnostic = { path = "../diagnostic" , version = "0.3.0" }
 
 base16 = { version = "0.2", optional = true }
 base64 = { version = "0.21", optional = true }
@@ -69,7 +69,7 @@ ofb = { version = "0.6.1", optional = true }
 dns-lookup = { version = "1.0.8", optional = true }
 hostname = { version = "0.3", optional = true }
 grok = { version = "2", optional = true }
-datadog-grok = { path = "../datadog/grok", optional = true }
+datadog-grok = { path = "../datadog/grok", optional = true , version = "0.3.0" }
 
 [dev-dependencies]
 anyhow = "1"

--- a/lib/tests/Cargo.toml
+++ b/lib/tests/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "vrl-tests"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-lookup = { path = "../lookup" }
+lookup = { path = "../lookup" , version = "0.3.0" }
 stdlib = { package = "vrl-stdlib", path = "../stdlib" }
-vrl = { path = "../.." }
-value = { path = "../value" }
+vrl = { path = "../.." , version = "0.3.0" }
+value = { path = "../value" , version = "0.3.0" }
 
 ansi_term = "0.12"
 chrono = "0.4"

--- a/lib/value/Cargo.toml
+++ b/lib/value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2021"
 license = "MPL-2.0"
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 bytes = { version = "1.4.0", default-features = false, features = ["serde"] }
 chrono = { version = "0.4.19", default-features = false, features = ["serde", "std"] }
-lookup = { path = "../lookup", default-features = false }
+lookup = { path = "../lookup", default-features = false , version = "0.3.0" }
 ordered-float = { version = "3.6.0", default-features = false }
 regex = { version = "1.7.2", default-features = false, features = ["std", "perf"]}
 snafu = { version = "0.7.4", default-features = false }

--- a/lib/web-playground/Cargo.toml
+++ b/lib/web-playground/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrl-web-playground"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,8 +10,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
-vrl = { path = "../..", default-features = false }
-value = { path = "../value", default-features = false }
+vrl = { path = "../..", default-features = false , version = "0.3.0" }
+value = { path = "../value", default-features = false , version = "0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.5"
 gloo-utils = { version = "0.1", features = ["serde"] }


### PR DESCRIPTION
Sets up the repo with the standard Jenkins setup, code ownership file and automatic semantic tagging. This involves resetting the semantic version in Cargo.toml to v0.3.0 since the version we have been using, e.g. v0.2.0.6, isn't a valid semver and breaks the tooling involved.

Ref: LOG-16869