### PR TITLE
fix: lookup segment handling when quoting is redundant

### DIFF
--- a/lib/lookup/src/lookup_buf/segmentbuf.rs
+++ b/lib/lookup/src/lookup_buf/segmentbuf.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 
 use inherent::inherent;
@@ -6,22 +7,55 @@ use quickcheck::{Arbitrary, Gen};
 
 use crate::{field, LookSegment, Segment};
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[derive(Debug, Eq, Ord, Clone, Hash)]
 pub struct FieldBuf {
     pub name: String,
     // This is a very lazy optimization to avoid having to scan for escapes.
     pub requires_quoting: bool,
+    // LOG-17092: Track whether the original was quoted so by default we can generate
+    // the same string as output from the parsed representation. This upholds the existing
+    // API that was previously implemented.
+    pub original_quoted: bool,
 }
 
 impl FieldBuf {
     pub fn as_str(&self) -> &str {
         &self.name
     }
+
+    /// Returns the field name only quoting the name if the field name contains characters
+    /// that would require it to be quoted. For fields that were parsed with quotes but do
+    /// not contain any characters that require quotes, the quotes will be omitted.
+    pub fn to_humanized_string(&self) -> String {
+        if self.requires_quoting {
+            format!(r#""{}""#, self.name)
+        } else {
+            self.name.clone()
+        }
+    }
+}
+
+// LOG-17092: Part of trying to validate whether a field segment is within a path
+// exposed an issue where `.segment_name == ."segment_name"` would evaluate to false
+// because the derived PartialEq and PartialOrd implementations checked the name and
+// requires_quoting field. We don't need to check the requires_quoting field since it's
+// only in the struct to avoid scanning the name field for quotable characters every time
+// the Field is turned into a string/str.
+impl PartialEq for FieldBuf {
+    fn eq(&self, other: &Self) -> bool {
+        self.name.eq(&other.name)
+    }
+}
+
+impl PartialOrd for FieldBuf {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.name.partial_cmp(&other.name)
+    }
 }
 
 impl Display for FieldBuf {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        if self.requires_quoting {
+        if self.requires_quoting || self.original_quoted {
             write!(formatter, r#""{}""#, self.name)
         } else {
             write!(formatter, "{}", self.name)
@@ -32,20 +66,24 @@ impl Display for FieldBuf {
 impl From<String> for FieldBuf {
     fn from(mut name: String) -> Self {
         let mut requires_quoting = false;
+        let mut original_quoted = false;
 
         if name.starts_with('\"') && name.ends_with('\"') {
             // There is unfortunately no way to make an owned substring of a string.
             // So we have to take a slice and clone it.
             let len = name.len();
             name = name[1..len - 1].to_string();
+            original_quoted = true;
+        }
+
+        if !field::is_valid_fieldname(&name) {
             requires_quoting = true;
-        } else if !field::is_valid_fieldname(&name) {
-            requires_quoting = true
         }
 
         Self {
             name,
             requires_quoting,
+            original_quoted,
         }
     }
 }

--- a/lib/lookup/src/lookup_buf/test.rs
+++ b/lib/lookup/src/lookup_buf/test.rs
@@ -30,6 +30,7 @@ fn field_is_quoted() {
         FieldBuf {
             name: "zork2".into(),
             requires_quoting: false,
+            original_quoted: false,
         },
         field
     );
@@ -39,6 +40,27 @@ fn field_is_quoted() {
         FieldBuf {
             name: "zork2-zoog".into(),
             requires_quoting: true,
+            original_quoted: false,
+        },
+        field
+    );
+
+    let field: FieldBuf = "\"zork2\"".into();
+    assert_eq!(
+        FieldBuf {
+            name: "zork2".into(),
+            requires_quoting: false,
+            original_quoted: true,
+        },
+        field
+    );
+
+    let field: FieldBuf = "\"zork2-zoog\"".into();
+    assert_eq!(
+        FieldBuf {
+            name: "zork2-zoog".into(),
+            requires_quoting: true,
+            original_quoted: true,
         },
         field
     );

--- a/lib/lookup/src/lookup_view/segment.rs
+++ b/lib/lookup/src/lookup_view/segment.rs
@@ -1,14 +1,37 @@
+use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 
 use inherent::inherent;
 
 use crate::{field, FieldBuf, LookSegment, SegmentBuf};
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[derive(Debug, Eq, Ord, Clone, Hash)]
 pub struct Field<'a> {
     pub name: &'a str,
     // This is a very lazy optimization to avoid having to scan for escapes.
     pub requires_quoting: bool,
+    // LOG-17092: Track whether the original was quoted so by default we can generate
+    // the same string as output from the parsed representation. This upholds the existing
+    // API that was previously implemented.
+    pub original_quoted: bool,
+}
+
+// LOG-17092: Part of trying to validate whether a field segment is within a path
+// exposed an issue where `.segment_name == ."segment_name"` would evaluate to false
+// because the derived PartialEq and PartialOrd implementations checked the name and
+// requires_quoting field. We don't need to check the requires_quoting field since it's
+// only in the struct to avoid scanning the name field for quotable characters every time
+// the Field is turned into a string/str.
+impl<'a> PartialEq for Field<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.name.eq(other.name)
+    }
+}
+
+impl<'a> PartialOrd for Field<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.name.partial_cmp(other.name)
+    }
 }
 
 impl<'a> Field<'a> {
@@ -16,13 +39,25 @@ impl<'a> Field<'a> {
         FieldBuf {
             name: self.name.to_string(),
             requires_quoting: self.requires_quoting,
+            original_quoted: self.original_quoted,
+        }
+    }
+
+    /// Returns the field name only quoting the name if the field name contains characters
+    /// that would require it to be quoted. For fields that were parsed with quotes but do
+    /// not contain any characters that require quotes, the quotes will be omitted.
+    pub fn to_humanized_string(&self) -> String {
+        if self.requires_quoting {
+            format!(r#""{}""#, self.name)
+        } else {
+            self.name.to_string()
         }
     }
 }
 
 impl<'a> Display for Field<'a> {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        if self.requires_quoting {
+        if self.requires_quoting || self.original_quoted {
             write!(formatter, r#""{}""#, self.name)
         } else {
             write!(formatter, r#"{}"#, self.name)
@@ -33,18 +68,22 @@ impl<'a> Display for Field<'a> {
 impl<'a> From<&'a str> for Field<'a> {
     fn from(mut name: &'a str) -> Self {
         let mut requires_quoting = false;
+        let mut original_quoted = false;
 
         if name.starts_with('\"') && name.ends_with('\"') {
             let len = name.len();
             name = &name[1..len - 1];
-            requires_quoting = true;
-        } else if !field::is_valid_fieldname(name) {
+            original_quoted = true;
+        }
+
+        if !field::is_valid_fieldname(name) {
             requires_quoting = true;
         }
 
         Self {
             name,
             requires_quoting,
+            original_quoted,
         }
     }
 }
@@ -54,6 +93,7 @@ impl<'a> From<&'a FieldBuf> for Field<'a> {
         Self {
             name: &v.name,
             requires_quoting: v.requires_quoting,
+            original_quoted: v.original_quoted,
         }
     }
 }
@@ -123,6 +163,7 @@ impl<'a> Display for Segment<'a> {
             Segment::Field(Field {
                 name,
                 requires_quoting: false,
+                original_quoted: false,
             }) => write!(formatter, "{}", name),
             Segment::Field(field) => write!(formatter, "{}", field),
             Segment::Coalesce(v) => write!(

--- a/lib/lookup/src/lookup_view/test.rs
+++ b/lib/lookup/src/lookup_view/test.rs
@@ -23,12 +23,28 @@ static SUFFICIENTLY_DECOMPOSED: Lazy<[Segment<'static>; 10]> = Lazy::new(|| {
 });
 
 #[test]
+fn field_eq_ignores_original_quoting() {
+    let field_1: Field = "a_name".into();
+    let field_2: Field = "\"a_name\"".into();
+
+    assert!(!field_1.requires_quoting);
+    assert!(!field_1.original_quoted);
+
+    assert!(!field_2.requires_quoting);
+    assert!(field_2.original_quoted);
+
+    assert_eq!(field_1, field_2);
+    assert_eq!(field_2, field_1);
+}
+
+#[test]
 fn field_is_quoted() {
     let field: Field = "zork2".into();
     assert_eq!(
         Field {
             name: "zork2",
             requires_quoting: false,
+            original_quoted: false,
         },
         field
     );
@@ -38,6 +54,27 @@ fn field_is_quoted() {
         Field {
             name: "zork2-zoog",
             requires_quoting: true,
+            original_quoted: false,
+        },
+        field
+    );
+
+    let field: FieldBuf = "\"zork2\"".into();
+    assert_eq!(
+        FieldBuf {
+            name: "zork2".into(),
+            requires_quoting: false,
+            original_quoted: true,
+        },
+        field
+    );
+
+    let field: Field = "\"zork2-zoog\"".into();
+    assert_eq!(
+        Field {
+            name: "zork2-zoog",
+            requires_quoting: true,
+            original_quoted: true,
         },
         field
     );


### PR DESCRIPTION
The lookup segment parsing and comparison code has a few odd behaviors when a segment does not need to be quoted but is.

1. The segment equality code also checks the internal boolean flags like `requires_quoting`. This then causes two segments to fail to be equal if quotes aren't required but one segment is quoted. For example, `name == "name"` should be true.

2. If a segment is quoted and doesn't need to be, it will be turned into a string with quotes. For building human readable text, we may want to optionally drop unnecessary quotes.

Ref: LOG-17092