### PR TITLE
feat: Expose fallible functions mezmo_to_object() and mezmo_to_array()

### DIFF
--- a/lib/stdlib/Cargo.toml
+++ b/lib/stdlib/Cargo.toml
@@ -170,8 +170,10 @@ default = [
     "mezmo_parse_float",
     "mezmo_parse_int",
     "mezmo_relational_comparison",
+    "mezmo_to_array",
     "mezmo_to_int",
     "mezmo_to_float",
+    "mezmo_to_object",
     "mezmo_to_string",
     "mezmo_string_operations",
     "mod",
@@ -341,8 +343,10 @@ mezmo_parse_int = ["parse_int"]
 mezmo_parse_float = []
 mezmo_relational_comparison = []
 mezmo_string_operations = ["substring"]
+mezmo_to_array = []
 mezmo_to_int = []
 mezmo_to_float = []
+mezmo_to_object = []
 mezmo_to_string = ["to_string"]
 mod = []
 now = ["dep:chrono"]

--- a/lib/stdlib/src/lib.rs
+++ b/lib/stdlib/src/lib.rs
@@ -204,28 +204,28 @@ mod md5;
 mod merge;
 #[cfg(feature = "mezmo_arithmetic_operation")]
 mod mezmo_arithmetic_operation;
+#[cfg(feature = "mezmo_string_operations")]
+mod mezmo_char_at;
 #[cfg(feature = "mezmo_arithmetic_operation")]
 mod mezmo_concat_or_add;
 #[cfg(feature = "mezmo_arithmetic_operation")]
 mod mezmo_concat_or_add_fallible;
-#[cfg(feature = "mezmo_is_truthy")]
-mod mezmo_is_truthy;
-#[cfg(feature = "mezmo_parse_float")]
-mod mezmo_parse_float;
-#[cfg(feature = "mezmo_parse_int")]
-mod mezmo_parse_int;
-#[cfg(feature = "mezmo_relational_comparison")]
-mod mezmo_relational_comparison;
-#[cfg(feature = "mezmo_string_operations")]
-mod mezmo_char_at;
 #[cfg(feature = "mezmo_string_operations")]
 mod mezmo_index_of;
+#[cfg(feature = "mezmo_is_truthy")]
+mod mezmo_is_truthy;
 #[cfg(feature = "mezmo_string_operations")]
 mod mezmo_last_index_of;
 #[cfg(feature = "mezmo_string_operations")]
 mod mezmo_pad_end;
 #[cfg(feature = "mezmo_string_operations")]
 mod mezmo_pad_start;
+#[cfg(feature = "mezmo_parse_float")]
+mod mezmo_parse_float;
+#[cfg(feature = "mezmo_parse_int")]
+mod mezmo_parse_int;
+#[cfg(feature = "mezmo_relational_comparison")]
+mod mezmo_relational_comparison;
 #[cfg(feature = "mezmo_string_operations")]
 mod mezmo_repeat;
 #[cfg(feature = "mezmo_string_operations")]
@@ -234,16 +234,20 @@ mod mezmo_string_at;
 mod mezmo_string_slice;
 #[cfg(feature = "mezmo_string_operations")]
 mod mezmo_substring;
+#[cfg(feature = "mezmo_to_array")]
+mod mezmo_to_array;
+#[cfg(feature = "mezmo_to_float")]
+mod mezmo_to_float;
+#[cfg(feature = "mezmo_to_int")]
+mod mezmo_to_int;
+#[cfg(feature = "mezmo_to_object")]
+mod mezmo_to_object;
+#[cfg(feature = "mezmo_to_string")]
+mod mezmo_to_string;
 #[cfg(feature = "mezmo_string_operations")]
 mod mezmo_trim_end;
 #[cfg(feature = "mezmo_string_operations")]
 mod mezmo_trim_start;
-#[cfg(feature = "mezmo_to_int")]
-mod mezmo_to_int;
-#[cfg(feature = "mezmo_to_float")]
-mod mezmo_to_float;
-#[cfg(feature = "mezmo_to_string")]
-mod mezmo_to_string;
 
 #[cfg(feature = "mod")]
 mod mod_func;
@@ -560,28 +564,28 @@ pub use match_datadog_query::MatchDatadogQuery;
 pub use merge::Merge;
 #[cfg(feature = "mezmo_arithmetic_operation")]
 pub use mezmo_arithmetic_operation::{MezmoDivide, MezmoMultiply, MezmoSubtract};
+#[cfg(feature = "mezmo_string_operations")]
+pub use mezmo_char_at::MezmoCharAt;
 #[cfg(feature = "mezmo_arithmetic_operation")]
 pub use mezmo_concat_or_add::MezmoConcatOrAdd;
 #[cfg(feature = "mezmo_arithmetic_operation")]
 pub use mezmo_concat_or_add_fallible::MezmoConcatOrAddFallible;
-#[cfg(feature = "mezmo_is_truthy")]
-pub use mezmo_is_truthy::MezmoIsTruthy;
-#[cfg(feature = "mezmo_parse_float")]
-pub use mezmo_parse_float::MezmoParseFloat;
-#[cfg(feature = "mezmo_parse_int")]
-pub use mezmo_parse_int::MezmoParseInt;
-#[cfg(feature = "mezmo_relational_comparison")]
-pub use mezmo_relational_comparison::{MezmoGt, MezmoGte, MezmoLt, MezmoLte};
-#[cfg(feature = "mezmo_string_operations")]
-pub use mezmo_char_at::MezmoCharAt;
 #[cfg(feature = "mezmo_string_operations")]
 pub use mezmo_index_of::MezmoIndexOf;
+#[cfg(feature = "mezmo_is_truthy")]
+pub use mezmo_is_truthy::MezmoIsTruthy;
 #[cfg(feature = "mezmo_string_operations")]
 pub use mezmo_last_index_of::MezmoLastIndexOf;
 #[cfg(feature = "mezmo_string_operations")]
 pub use mezmo_pad_end::MezmoPadEnd;
 #[cfg(feature = "mezmo_string_operations")]
 pub use mezmo_pad_start::MezmoPadStart;
+#[cfg(feature = "mezmo_parse_float")]
+pub use mezmo_parse_float::MezmoParseFloat;
+#[cfg(feature = "mezmo_parse_int")]
+pub use mezmo_parse_int::MezmoParseInt;
+#[cfg(feature = "mezmo_relational_comparison")]
+pub use mezmo_relational_comparison::{MezmoGt, MezmoGte, MezmoLt, MezmoLte};
 #[cfg(feature = "mezmo_string_operations")]
 pub use mezmo_repeat::MezmoRepeat;
 #[cfg(feature = "mezmo_string_operations")]
@@ -590,16 +594,20 @@ pub use mezmo_string_at::MezmoStringAt;
 pub use mezmo_string_slice::MezmoStringSlice;
 #[cfg(feature = "mezmo_string_operations")]
 pub use mezmo_substring::MezmoSubstring;
+#[cfg(feature = "mezmo_to_array")]
+pub use mezmo_to_array::MezmoToArray;
+#[cfg(feature = "mezmo_to_float")]
+pub use mezmo_to_float::MezmoToFloat;
+#[cfg(feature = "mezmo_to_int")]
+pub use mezmo_to_int::MezmoToInt;
+#[cfg(feature = "mezmo_to_object")]
+pub use mezmo_to_object::MezmoToObject;
+#[cfg(feature = "mezmo_to_string")]
+pub use mezmo_to_string::MezmoToString;
 #[cfg(feature = "mezmo_string_operations")]
 pub use mezmo_trim_end::MezmoTrimEnd;
 #[cfg(feature = "mezmo_string_operations")]
 pub use mezmo_trim_start::MezmoTrimStart;
-#[cfg(feature = "mezmo_to_int")]
-pub use mezmo_to_int::MezmoToInt;
-#[cfg(feature = "mezmo_to_float")]
-pub use mezmo_to_float::MezmoToFloat;
-#[cfg(feature = "mezmo_to_string")]
-pub use mezmo_to_string::MezmoToString;
 #[cfg(feature = "mod")]
 pub use mod_func::Mod;
 #[cfg(feature = "now")]
@@ -973,10 +981,14 @@ pub fn all() -> Vec<Box<dyn Function>> {
         Box::new(MezmoTrimEnd),
         #[cfg(feature = "mezmo_string_operations")]
         Box::new(MezmoTrimStart),
+        #[cfg(feature = "mezmo_to_array")]
+        Box::new(MezmoToArray),
         #[cfg(feature = "mezmo_to_int")]
         Box::new(MezmoToInt),
         #[cfg(feature = "mezmo_to_float")]
         Box::new(MezmoToFloat),
+        #[cfg(feature = "mezmo_to_object")]
+        Box::new(MezmoToObject),
         #[cfg(feature = "mezmo_to_string")]
         Box::new(MezmoToString),
         #[cfg(feature = "mod")]

--- a/lib/stdlib/src/mezmo_to_array.rs
+++ b/lib/stdlib/src/mezmo_to_array.rs
@@ -1,0 +1,87 @@
+use ::value::Value;
+use vrl_compiler::prelude::*;
+
+fn to_array(value: Value) -> Resolved {
+    use Value::Array;
+
+    match value {
+        Array(value) => Ok(Array(value)),
+        v => Err(format!("unable to coerce {} into array", v.kind()).into()),
+    }
+}
+
+/// Equivalent as the stdlib `array()` with non-conditional fallibility.
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoToArray;
+
+impl Function for MezmoToArray {
+    fn identifier(&self) -> &'static str {
+        "mezmo_to_array"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::ANY,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[]
+    }
+
+    fn compile(
+        &self,
+        _state: &state::TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(ToIntFn { value }.as_expr())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ToIntFn {
+    value: Box<dyn Expression>,
+}
+
+impl FunctionExpression for ToIntFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        to_array(value)
+    }
+
+    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
+        TypeDef::array(Collection::any()).fallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        mezmo_to_array => MezmoToArray;
+
+        float {
+            args: func_args![value: 20.5],
+            want: Err("unable to coerce float into array"),
+            tdef: TypeDef::array(Collection::any()).fallible(),
+        }
+
+        array {
+            args: func_args![value: value!([1, 2, 3])],
+            want: Ok(value!([1, 2, 3])),
+            tdef: TypeDef::array(Collection::any()).fallible(),
+        }
+
+        null {
+            args: func_args![value: value!(null)],
+            want: Err("unable to coerce null into array"),
+            tdef: TypeDef::array(Collection::any()).fallible(),
+        }
+    ];
+}

--- a/lib/stdlib/src/mezmo_to_object.rs
+++ b/lib/stdlib/src/mezmo_to_object.rs
@@ -1,0 +1,87 @@
+use ::value::Value;
+use vrl_compiler::prelude::*;
+
+fn to_object(value: Value) -> Resolved {
+    use Value::Object;
+
+    match value {
+        Object(value) => Ok(Object(value)),
+        v => Err(format!("unable to coerce {} into object", v.kind()).into()),
+    }
+}
+
+/// Equivalent as the stdlib `object()` with non-conditional fallibility.
+#[derive(Clone, Copy, Debug)]
+pub struct MezmoToObject;
+
+impl Function for MezmoToObject {
+    fn identifier(&self) -> &'static str {
+        "mezmo_to_object"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::ANY,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[]
+    }
+
+    fn compile(
+        &self,
+        _state: &state::TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(ToIntFn { value }.as_expr())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ToIntFn {
+    value: Box<dyn Expression>,
+}
+
+impl FunctionExpression for ToIntFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        to_object(value)
+    }
+
+    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
+        TypeDef::object(Collection::any()).fallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        mezmo_to_object => MezmoToObject;
+
+        integer {
+            args: func_args![value: 20],
+            want: Err("unable to coerce integer into object"),
+            tdef: TypeDef::object(Collection::any()).fallible(),
+        }
+
+        array {
+            args: func_args![value: value!({hello: "object"})],
+            want: Ok(value!({hello: "object"})),
+            tdef: TypeDef::object(Collection::any()).fallible(),
+        }
+
+        null {
+            args: func_args![value: value!(null)],
+            want: Err("unable to coerce null into object"),
+            tdef: TypeDef::object(Collection::any()).fallible(),
+        }
+    ];
+}


### PR DESCRIPTION
Expose functions equivalent to object() and array() in VRL but with a signature that is always fallible.

Ref: LOG-17868