### PR TITLE
fix(cli): Use same fn list for repl and script execution

### DIFF
--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -141,7 +141,7 @@ fn run(opts: &Opts, stdlib_functions: Vec<Box<dyn Function>>) -> Result<(), Erro
             config: _,
         } = compile_with_state(
             &source,
-            &crate::stdlib::all(),
+            &stdlib_functions,
             &state,
             CompileConfig::default(),
         )


### PR DESCRIPTION
The CLI execution function doesn't use the supplied VRL function list when executing a script from command line flags but does use that list when executing in the REPL. This commit ensures both execution models behave the same.

Ref: LOG-19051