### PR TITLE
chore(mezmo_redact): Export mezmo redact and matching patterns

### DIFF
--- a/src/stdlib/mezmo_matching_patterns.rs
+++ b/src/stdlib/mezmo_matching_patterns.rs
@@ -45,9 +45,9 @@ fn process_collection(values: impl Iterator<Item = Value>, pattern: &RegexSet) -
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct MatchingPatterns;
+pub struct MezmoMatchingPatterns;
 
-impl Function for MatchingPatterns {
+impl Function for MezmoMatchingPatterns {
     fn identifier(&self) -> &'static str {
         "mezmo_matching_patterns"
     }
@@ -169,7 +169,7 @@ mod tests {
     use regex::Regex;
 
     test_function![
-        matching_patterns => MatchingPatterns;
+        matching_patterns => MezmoMatchingPatterns;
 
         string_value {
             args: func_args![value: "foobar",

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -334,7 +334,7 @@ cfg_if::cfg_if! {
         pub use mezmo_is_truthy::MezmoIsTruthy;
         pub use mezmo_last_index_of::MezmoLastIndexOf;
         pub use mezmo_length::MezmoLength;
-        pub use mezmo_matching_patterns::MatchingPatterns;
+        pub use mezmo_matching_patterns::MezmoMatchingPatterns;
         pub use mezmo_pad_end::MezmoPadEnd;
         pub use mezmo_pad_start::MezmoPadStart;
         pub use mezmo_parse_float::MezmoParseFloat;
@@ -542,11 +542,13 @@ pub fn all() -> Vec<Box<dyn Function>> {
         Box::new(MezmoLength),
         Box::new(MezmoLt),
         Box::new(MezmoLte),
+        Box::new(MezmoMatchingPatterns),
         Box::new(MezmoMultiply),
         Box::new(MezmoPadEnd),
         Box::new(MezmoPadStart),
         Box::new(MezmoParseFloat),
         Box::new(MezmoParseInt),
+        Box::new(MezmoRedact),
         Box::new(MezmoRepeat),
         Box::new(MezmoSetTsComponents),
         Box::new(MezmoStringAt),


### PR DESCRIPTION
Add boxed initializations of the mezmo_redact and
mezmo_matching_patterns to the list of exported
functions.

Ref: LOG-20230